### PR TITLE
Add import command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -16,10 +16,11 @@ done faster and more securely than traditional GUI apps.
 - [Features](#features)
     * [Adding a client: `add`](#adding-a-client-add)
     * [Editing a client: `edit`](#editing-a-client--edit)
-    * [Deleting a client : `delete`](#deleting-a-client--delete)
-    * [Listing all clients : `list`](#listing-all-clients-list)
-    * [Exiting the application : `exit`](#exiting-the-application--exit)
+    * [Deleting a client: `delete`](#deleting-a-client--delete)
+    * [Listing all clients: `list`](#listing-all-clients-list)
+    * [Exiting the application: `exit`](#exiting-the-application--exit)
     * [Saving the data](#saving-the-data)
+    * [Importing data: `import`](#importing-data--import)
 - [FAQ](#faq)
 - [Command Summary](#command-summary)
 
@@ -175,7 +176,23 @@ If your changes to the data file makes its format invalid, FinBook will discard 
 
 ---
 
-### Importing data from external sources [coming soon]
+### Importing data : `import`
+
+Imports data from a `JSON` or `CSV` file
+
+* `JSON` files must be saved by the latest version of FinBook
+* `CSV` files must be exported as Google CSV from Google Contacts
+
+Format: `import PATH`
+
+* Imports data from the file at the specified `PATH`
+* `PATH` can be a relative or full path
+* `PATH` must end in `.json` or `.csv`
+
+Examples:
+
+* `import ./data.json` imports data from the file `data.json` which is located in the same directory as the FinBook executable
+* `import ../data.csv` imports data from the file `data.csv` which is located one level outside the directory of the FinBook executable
 
 --------------------------------------------------------------------------------------------------------------------
 
@@ -183,16 +200,17 @@ If your changes to the data file makes its format invalid, FinBook will discard 
 
 **Q**: How do I transfer my data to another Computer?<br>
 **A**: Install the app in the other computer and overwrite the empty data file it creates with the file that contains
-the data of your previous FinBook home folder.
+the data of your previous FinBook home folder. Alternatively, you may use the `import` command.
 
 --------------------------------------------------------------------------------------------------------------------
 
 ## Command summary
 
-Action               | Format, Examples
----------------------|------------------
-**Add**              | `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS i/MONTHLY_INCOME m/UPCOMING_MEETING_DATES​` <br> e.g., `add n/John Doe p/98765432 e/johnd@example.com a/John street, block 123, #01-01 i/$100000 m/12-Jan-2022`
-**Delete**           | `delete INDEX`<br> e.g., `delete 3`
-**Edit**             | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com`
-**List**             | `list`
-**Exit application** | `exit`
+| Action               | Format, Examples                                                                                                                                                                                             |
+|----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Add**              | `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS i/MONTHLY_INCOME m/UPCOMING_MEETING_DATES​` <br> e.g., `add n/John Doe p/98765432 e/johnd@example.com a/John street, block 123, #01-01 i/$100000 m/12-Jan-2022` |
+| **Delete**           | `delete INDEX`<br> e.g., `delete 3`                                                                                                                                                                          |
+| **Edit**             | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com`                                                                                  |
+| **List**             | `list`                                                                                                                                                                                                       |
+| **Exit application** | `exit`                                                                                                                                                                                                       |
+| **Import**           | `import PATH`<br> e.g., `import ./data.json`                                                                                                                                                                 |

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -9,5 +9,7 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
+    public static final String MESSAGE_INVALID_FILE_PATH = "Invalid file path! \n%1$s";
+    public static final String MESSAGE_IMPORT_ERROR = "Error encountered while importing: \n%1$s";
 
 }

--- a/src/main/java/seedu/address/logic/commands/ImportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ImportCommand.java
@@ -19,7 +19,13 @@ public class ImportCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Imports data from the JSON or CSV file located at the specified path.\n"
             + "Parameters: path to JSON or CSV file\n"
-            + "Example: " + COMMAND_WORD + " ./somewhere/addressbook.json";
+            + "Examples: \n"
+            + COMMAND_WORD + " ./data.json\n"
+            + "- imports data from the file \"data.json\""
+            + " which is located in the same directory as the FinBook executable\n"
+            + COMMAND_WORD + " ../data.csv\n"
+            + "- imports data from the file \"data.csv\""
+            + " which is located one level outside the directory of the FinBook executable";
 
     public static final String MESSAGE_IMPORT_DATA_SUCCESS = "Imported data: %1$s";
 

--- a/src/main/java/seedu/address/logic/commands/ImportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ImportCommand.java
@@ -1,0 +1,52 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_IMPORT_ERROR;
+
+import java.nio.file.Path;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.storage.JsonAddressBookStorage;
+
+/**
+ * Imports data from the JSON or CSV file located at the specified path into FinBook.
+ */
+public class ImportCommand extends Command {
+
+    public static final String COMMAND_WORD = "import";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Imports data from the JSON or CSV file located at the specified path.\n"
+            + "Parameters: path to JSON or CSV file\n"
+            + "Example: " + COMMAND_WORD + " ./somewhere/addressbook.json";
+
+    public static final String MESSAGE_IMPORT_DATA_SUCCESS = "Imported data: %1$s";
+
+    private final Path targetPath;
+
+    public ImportCommand(Path targetPath) {
+        this.targetPath = targetPath;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        if (targetPath.toString().toLowerCase().endsWith(".json")) {
+            JsonAddressBookStorage tempStorage = new JsonAddressBookStorage(targetPath);
+            try {
+                tempStorage.readAddressBook().ifPresent(x -> x.getPersonList().forEach(y -> model.addPerson(y)));
+            } catch (Exception e) {
+                throw new CommandException(String.format(MESSAGE_IMPORT_ERROR, e.getMessage()));
+            }
+        }
+        return new CommandResult(String.format(MESSAGE_IMPORT_DATA_SUCCESS, targetPath.getFileName()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ImportCommand // instanceof handles nulls
+                && targetPath.equals(((ImportCommand) other).targetPath)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -14,6 +14,7 @@ import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.ImportCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -67,6 +68,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case ImportCommand.COMMAND_WORD:
+            return new ImportCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/ImportCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ImportCommandParser.java
@@ -1,0 +1,31 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_FILE_PATH;
+
+import java.nio.file.Path;
+
+import seedu.address.logic.commands.ImportCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new ImportCommand object
+ */
+public class ImportCommandParser implements Parser<ImportCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the ImportCommand
+     * and returns an ImportCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ImportCommand parse(String args) throws ParseException {
+        try {
+            Path path = ParserUtil.parsePath(args);
+            return new ImportCommand(path);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_FILE_PATH, ImportCommand.MESSAGE_USAGE), pe);
+        }
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -2,6 +2,9 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -23,9 +26,12 @@ public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
 
+    public static final String MESSAGE_INVALID_PATH = "Path is invalid.";
+
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
      * trimmed.
+     *
      * @throws ParseException if the specified index is invalid (not non-zero unsigned integer).
      */
     public static Index parseIndex(String oneBasedIndex) throws ParseException {
@@ -136,5 +142,21 @@ public class ParserUtil {
             tagSet.add(parseTag(tagName));
         }
         return tagSet;
+    }
+
+    /**
+     * Parses {@code filePath} into an {@code Path} and returns it. Leading and trailing whitespaces will be
+     * trimmed.
+     *
+     * @throws ParseException if the specified path is invalid.
+     */
+    public static Path parsePath(String filePath) throws ParseException {
+        String trimmedPath = filePath.trim();
+        File file = new File(trimmedPath);
+        if (!(file.getName().toLowerCase().endsWith(".json") || file.getName().toLowerCase().endsWith(".csv"))
+                || !Files.isReadable(file.toPath())) {
+            throw new ParseException(MESSAGE_INVALID_PATH);
+        }
+        return file.toPath();
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
@@ -1,0 +1,109 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.commons.core.Messages.MESSAGE_IMPORT_ERROR;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TestUtil.getFilePathInSandboxFolder;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.exceptions.DuplicatePersonException;
+import seedu.address.storage.JsonAddressBookStorage;
+import seedu.address.testutil.PersonBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code ImportCommand}.
+ */
+public class ImportCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Path dummyPath = getFilePathInSandboxFolder("foobar.json");
+    private Path dummyPath2 = Paths.get("foobar2.json");
+    private File dummyFile = new File(dummyPath.toUri());
+
+    @Test
+    public void execute_validJson_success() {
+        Model validModel = new ModelManager(new AddressBook(), new UserPrefs());
+        Person validPerson = new PersonBuilder().build();
+        validModel.addPerson(validPerson);
+        JsonAddressBookStorage storage = new JsonAddressBookStorage(dummyPath);
+        try {
+            dummyFile.createNewFile();
+            storage.saveAddressBook(validModel.getAddressBook());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        ImportCommand importCommand = new ImportCommand(dummyPath);
+
+        String expectedMessage = String.format(ImportCommand.MESSAGE_IMPORT_DATA_SUCCESS, dummyPath.getFileName());
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.addPerson(validPerson);
+
+        assertCommandSuccess(importCommand, model, expectedMessage, expectedModel);
+        dummyFile.delete();
+    }
+
+    @Test
+    public void execute_invalidJson_throwsCommandException() {
+        JsonAddressBookStorage storage = new JsonAddressBookStorage(dummyPath);
+        try {
+            dummyFile.createNewFile();
+            storage.saveAddressBook(model.getAddressBook());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        ImportCommand importCommand = new ImportCommand(dummyPath);
+
+        assertCommandFailure(importCommand, model,
+                String.format(MESSAGE_IMPORT_ERROR, new DuplicatePersonException().getMessage()));
+    }
+
+    @Test
+    public void execute_validCsv_success() {
+        // to be implemented
+    }
+
+    @Test
+    public void execute_invalidCsv_throwsCommandException() {
+        // to be implemented
+    }
+
+    @Test
+    public void equals() {
+        ImportCommand importFirstCommand = new ImportCommand(dummyPath);
+        ImportCommand importSecondCommand = new ImportCommand(dummyPath2);
+
+        // same object -> returns true
+        assertTrue(importFirstCommand.equals(importFirstCommand));
+
+        // same values -> returns true
+        ImportCommand importFirstCommandCopy = new ImportCommand(dummyPath);
+        assertTrue(importFirstCommand.equals(importFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(importFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(importFirstCommand.equals(null));
+
+        // different path -> returns false
+        assertFalse(importFirstCommand.equals(importSecondCommand));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -5,8 +5,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TestUtil.getFilePathInSandboxFolder;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
+import java.io.File;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -21,6 +24,7 @@ import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.ImportCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
@@ -91,11 +95,22 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_unrecognisedInput_throwsParseException() {
         assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), ()
-            -> parser.parseCommand(""));
+                -> parser.parseCommand(""));
     }
 
     @Test
     public void parseCommand_unknownCommand_throwsParseException() {
         assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () -> parser.parseCommand("unknownCommand"));
+    }
+
+    @Test
+    public void parseCommand_import() throws Exception {
+        Path dummyPath = getFilePathInSandboxFolder("foobar.json");
+        File dummyFile = new File(dummyPath.toUri());
+        dummyFile.createNewFile();
+        ImportCommand command = (ImportCommand) parser.parseCommand(
+                ImportCommand.COMMAND_WORD + " " + dummyPath.toString());
+        assertEquals(new ImportCommand(dummyPath), command);
+        dummyFile.delete();
     }
 }

--- a/src/test/java/seedu/address/logic/parser/ImportCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ImportCommandParserTest.java
@@ -1,0 +1,50 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_FILE_PATH;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TestUtil.getFilePathInSandboxFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.ImportCommand;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+import seedu.address.storage.JsonAddressBookStorage;
+import seedu.address.testutil.PersonBuilder;
+
+public class ImportCommandParserTest {
+
+    private ImportCommandParser parser = new ImportCommandParser();
+
+    private Path dummyPath = getFilePathInSandboxFolder("foobar.json");
+    private File dummyFile = new File(dummyPath.toUri());
+
+    @Test
+    public void parse_validArgs_returnsImportCommand() {
+        Model validModel = new ModelManager(new AddressBook(), new UserPrefs());
+        Person validPerson = new PersonBuilder().build();
+        validModel.addPerson(validPerson);
+        JsonAddressBookStorage storage = new JsonAddressBookStorage(dummyPath);
+        try {
+            dummyFile.createNewFile();
+            storage.saveAddressBook(validModel.getAddressBook());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        assertParseSuccess(parser, "src/test/data/sandbox/foobar.json", new ImportCommand(dummyPath));
+        dummyFile.delete();
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_FILE_PATH, ImportCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -3,9 +3,13 @@ package seedu.address.logic.parser;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
+import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_PATH;
 import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TestUtil.getFilePathInSandboxFolder;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
+import java.io.File;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -44,7 +48,7 @@ public class ParserUtilTest {
     @Test
     public void parseIndex_outOfRangeInput_throwsParseException() {
         assertThrows(ParseException.class, MESSAGE_INVALID_INDEX, ()
-            -> ParserUtil.parseIndex(Long.toString(Integer.MAX_VALUE + 1)));
+                -> ParserUtil.parseIndex(Long.toString(Integer.MAX_VALUE + 1)));
     }
 
     @Test
@@ -192,5 +196,29 @@ public class ParserUtilTest {
         Set<Tag> expectedTagSet = new HashSet<Tag>(Arrays.asList(new Tag(VALID_TAG_1), new Tag(VALID_TAG_2)));
 
         assertEquals(expectedTagSet, actualTagSet);
+    }
+
+    @Test
+    public void parsePath_invalidInput_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parsePath("10 a"));
+    }
+
+    @Test
+    public void parsePath_notReadable_throwsParseException() {
+        assertThrows(ParseException.class, MESSAGE_INVALID_PATH, ()
+                -> ParserUtil.parsePath("foobar.json"));
+    }
+
+    @Test
+    public void parsePath_validInput_success() throws Exception {
+        Path dummyPath = getFilePathInSandboxFolder("foobar.json");
+        File dummyFile = new File(dummyPath.toUri());
+        dummyFile.createNewFile();
+        // No whitespaces
+        assertEquals(dummyPath, ParserUtil.parsePath(dummyPath.toString()));
+
+        // Leading and trailing whitespaces
+        assertEquals(dummyPath, ParserUtil.parsePath("  " + dummyPath.toString() + "  "));
+        dummyFile.delete();
     }
 }


### PR DESCRIPTION
## Add `import` command
**usage:** `import <path to file>`
**example:** `import ./data/addressbook.json)` 

This command can be used to import persons from an existing save file in `json` format.

See diff for details on files added and modified.

### **Todo:**
- [x] implement `import` command
- [x] add new test cases
- [x] update user guide

### Plans for v1.2b
Extend `import` command to support importing `CSV` files exported from Google Contacts
