### PR TITLE
Add CSV import

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ task coverage(type: JacocoReport) {
 }
 
 dependencies {
+    implementation 'com.opencsv:opencsv:5.7.0'
     String jUnitVersion = '5.4.0'
     String javaFxVersion = '11'
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -486,7 +486,7 @@ Use case ends.
 
 **Use case: UC 7 - Import external data**
 
-**Precondition:** Actor exported data from Google contacts as Google CSV
+**Precondition:** Actor has a valid file
 
 **MSS:**
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -181,7 +181,16 @@ If your changes to the data file makes its format invalid, FinBook will discard 
 Imports data from a `JSON` or `CSV` file
 
 * `JSON` files must be saved by the latest version of FinBook
-* `CSV` files must be exported as Google CSV from Google Contacts
+* `CSV` files must be formatted correctly as follows:
+    * The first line of the file must contain these headers in any order:
+        * `name`
+        * `phone`
+        * `email`
+        * `address`
+        * `income`
+        * `meeting date`
+        * `tags`
+    * The data in each corresponding column must be valid
 
 Format: `import PATH`
 

--- a/src/main/java/seedu/address/storage/CsvAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/CsvAdaptedPerson.java
@@ -1,0 +1,158 @@
+package seedu.address.storage;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import com.opencsv.bean.CsvBindAndSplitByName;
+import com.opencsv.bean.CsvBindByName;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.meeting.MeetingDate;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Income;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+import seedu.address.model.tag.Tag;
+
+/**
+ * OpenCSV-friendly version of {@link Person}.
+ */
+public class CsvAdaptedPerson {
+
+    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Person's %s field is missing!";
+
+    @CsvBindByName(required = true)
+    private final String name;
+    @CsvBindByName(required = true)
+    private final String phone;
+    @CsvBindByName(required = true)
+    private final String email;
+    @CsvBindByName(required = true)
+    private final String address;
+    @CsvBindByName(required = true)
+    private final String income;
+    @CsvBindByName(column = "meeting date", required = true)
+    private final String meetingDate;
+    @CsvBindAndSplitByName(column = "tags", required = true,
+            elementType = Tag.class, splitOn = ",", converter = StringToTag.class)
+    private final List<Tag> tagged = new ArrayList<>();
+
+    /**
+     * OpenCSV requires a public nullary constructor
+     */
+    public CsvAdaptedPerson() {
+        this.name = null;
+        this.phone = null;
+        this.email = null;
+        this.address = null;
+        this.income = null;
+        this.meetingDate = null;
+    }
+
+    /**
+     * Constructs a {@code CsvAdaptedPerson} with the given person details.
+     */
+    public CsvAdaptedPerson(String name, String phone,
+                            String email, String address,
+                            String income,
+                            String meetingDate,
+                            List<Tag> tagged) {
+        this.name = name;
+        this.phone = phone;
+        this.email = email;
+        this.address = address;
+        this.income = income;
+        if (meetingDate != null) {
+            this.meetingDate = meetingDate;
+        } else {
+            this.meetingDate = "";
+        }
+        if (tagged != null) {
+            this.tagged.addAll(tagged);
+        }
+    }
+
+    /**
+     * Converts a given {@code Person} into this class for OpenCSV use.
+     */
+    public CsvAdaptedPerson(Person source) {
+        name = source.getName().fullName;
+        phone = source.getPhone().value;
+        email = source.getEmail().value;
+        address = source.getAddress().value;
+        income = source.getIncome().value;
+        meetingDate = source.getMeetingDate().value;
+        tagged.addAll(source.getTags());
+    }
+
+    /**
+     * Converts this OpenCSV-friendly adapted person object into the model's {@code Person} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted person.
+     */
+    public Person toModelType() throws IllegalValueException {
+        final List<Tag> personTags = new ArrayList<>();
+        for (Tag tag : tagged) {
+            personTags.add(tag);
+        }
+
+        if (name == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName()));
+        }
+        if (!Name.isValidName(name)) {
+            throw new IllegalValueException(Name.MESSAGE_CONSTRAINTS);
+        }
+        final Name modelName = new Name(name);
+
+        if (phone == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName()));
+        }
+        if (!Phone.isValidPhone(phone)) {
+            throw new IllegalValueException(Phone.MESSAGE_CONSTRAINTS);
+        }
+        final Phone modelPhone = new Phone(phone);
+
+        if (email == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName()));
+        }
+        if (!Email.isValidEmail(email)) {
+            throw new IllegalValueException(Email.MESSAGE_CONSTRAINTS);
+        }
+        final Email modelEmail = new Email(email);
+
+        if (address == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName()));
+        }
+        if (!Address.isValidAddress(address)) {
+            throw new IllegalValueException(Address.MESSAGE_CONSTRAINTS);
+        }
+        final Address modelAddress = new Address(address);
+
+        if (income == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Income.class.getSimpleName()));
+        }
+        if (!Income.isValidIncome(income)) {
+            throw new IllegalValueException(Income.MESSAGE_CONSTRAINTS);
+        }
+        final Income modelIncome = new Income(income);
+
+        if (meetingDate != null && !MeetingDate.isValidMeetingDate(meetingDate)) {
+            throw new IllegalValueException(MeetingDate.MESSAGE_CONSTRAINTS);
+        }
+        final MeetingDate modelMeetingDate;
+
+        if (meetingDate != null) {
+            modelMeetingDate = new MeetingDate(meetingDate);
+        } else {
+            modelMeetingDate = new MeetingDate("");
+        }
+
+        final Set<Tag> modelTags = new HashSet<>(personTags);
+        return new Person(modelName, modelPhone, modelEmail, modelAddress, modelIncome, modelMeetingDate, modelTags);
+    }
+
+}

--- a/src/main/java/seedu/address/storage/StringToTag.java
+++ b/src/main/java/seedu/address/storage/StringToTag.java
@@ -1,0 +1,23 @@
+package seedu.address.storage;
+
+import com.opencsv.bean.AbstractCsvConverter;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Converts a given {@code String} into {@code Tag} for OpenCSV use.
+ */
+public class StringToTag extends AbstractCsvConverter {
+    @Override
+    public Object convertToRead(String value) {
+        if (!Tag.isValidTagName(value)) {
+            try {
+                throw new IllegalValueException(Tag.MESSAGE_CONSTRAINTS);
+            } catch (IllegalValueException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return new Tag(value);
+    }
+}

--- a/src/test/data/ImportCsvTest/invalidCsv.csv
+++ b/src/test/data/ImportCsvTest/invalidCsv.csv
@@ -1,0 +1,7 @@
+phone,email,address,income,meeting date,tags
+87438807,alexyeoh@example.com,"Blk 30 Geylang Street 29, #06-40",$1000,12 Nov 2022,friends
+99272758,berniceyu@example.com,"Blk 30 Lorong 3 Serangoon Gardens, #07-18",$5300,20 Nov 2022,"colleagues,friends"
+93210283,charlotte@example.com,"Blk 11 Ang Mo Kio Street 74, #11-04",$3080,08 Nov 2022,neighbours
+91031282,lidavid@example.com,"Blk 436 Serangoon Gardens Street 26, #16-43",$440,13 Dec 2022,family
+92492021,irfan@example.com,"Blk 47 Tampines Street 20, #17-35",$12000,15 Nov 2022,classmates
+92624417,royb@example.com,"Blk 45 Aljunied Street 85, #11-31",$800,03 Oct 2022,colleagues

--- a/src/test/data/ImportCsvTest/validCsv.csv
+++ b/src/test/data/ImportCsvTest/validCsv.csv
@@ -1,0 +1,7 @@
+name,phone,email,address,income,meeting date,tags
+Alex Yeoh,87438807,alexyeoh@example.com,"Blk 30 Geylang Street 29, #06-40",$1000,12 Nov 2022,friends
+Bernice Yu,99272758,berniceyu@example.com,"Blk 30 Lorong 3 Serangoon Gardens, #07-18",$5300,20 Nov 2022,"colleagues,friends"
+Charlotte Oliveiro,93210283,charlotte@example.com,"Blk 11 Ang Mo Kio Street 74, #11-04",$3080,08 Nov 2022,neighbours
+David Li,91031282,lidavid@example.com,"Blk 436 Serangoon Gardens Street 26, #16-43",$440,13 Dec 2022,family
+Irfan Ibrahim,92492021,irfan@example.com,"Blk 47 Tampines Street 20, #17-35",$12000,15 Nov 2022,classmates
+Roy Balakrishnan,92624417,royb@example.com,"Blk 45 Aljunied Street 85, #11-31",$800,03 Oct 2022,colleagues

--- a/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_IMPORT_ERROR;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.model.util.SampleDataUtil.getSamplePersons;
 import static seedu.address.testutil.TestUtil.getFilePathInSandboxFolder;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
@@ -34,6 +35,9 @@ public class ImportCommandTest {
     private Path dummyPath = getFilePathInSandboxFolder("foobar.json");
     private Path dummyPath2 = Paths.get("foobar2.json");
     private File dummyFile = new File(dummyPath.toUri());
+
+    private Path validCsv = Paths.get("src/test/data/ImportCsvTest/validCsv.csv");
+    private Path invalidCsv = Paths.get("src/test/data/ImportCsvTest/invalidCsv.csv");
 
     @Test
     public void execute_validJson_success() {
@@ -77,12 +81,24 @@ public class ImportCommandTest {
 
     @Test
     public void execute_validCsv_success() {
-        // to be implemented
+        ImportCommand importCommand = new ImportCommand(validCsv);
+
+        String expectedMessage = String.format(ImportCommand.MESSAGE_IMPORT_DATA_SUCCESS, validCsv.getFileName());
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        for (Person person : getSamplePersons()) {
+            expectedModel.addPerson(person);
+        }
+
+        assertCommandSuccess(importCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_invalidCsv_throwsCommandException() {
-        // to be implemented
+        ImportCommand importCommand = new ImportCommand(invalidCsv);
+
+        assertCommandFailure(importCommand, model,
+                String.format(MESSAGE_IMPORT_ERROR, "Error capturing CSV header!"));
     }
 
     @Test

--- a/src/test/java/seedu/address/storage/CsvAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/CsvAdaptedPersonTest.java
@@ -1,0 +1,133 @@
+package seedu.address.storage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.storage.CsvAdaptedPerson.MISSING_FIELD_MESSAGE_FORMAT;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalPersons.BENSON;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.meeting.MeetingDate;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Income;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Phone;
+import seedu.address.model.tag.Tag;
+
+
+public class CsvAdaptedPersonTest {
+    private static final String INVALID_NAME = "R@chel";
+    private static final String INVALID_PHONE = "+651234";
+    private static final String INVALID_ADDRESS = " ";
+    private static final String INVALID_INCOME = "3";
+    private static final String INVALID_EMAIL = "example.com";
+    private static final String INVALID_MEETING_DATE = "@2 Jan 2022";
+    private static final String INVALID_TAG = "#friend";
+
+    private static final String VALID_NAME = BENSON.getName().toString();
+    private static final String VALID_PHONE = BENSON.getPhone().toString();
+    private static final String VALID_EMAIL = BENSON.getEmail().toString();
+    private static final String VALID_ADDRESS = BENSON.getAddress().toString();
+    private static final String VALID_INCOME = BENSON.getIncome().toString();
+    private static final String VALID_MEETING_DATE = BENSON.getMeetingDate().toString();
+    private static final List<Tag> VALID_TAGS = new ArrayList<>(BENSON.getTags());
+
+    @Test
+    public void toModelType_validPersonDetails_returnsPerson() throws Exception {
+        CsvAdaptedPerson person = new CsvAdaptedPerson(BENSON);
+        assertEquals(BENSON, person.toModelType());
+    }
+
+    @Test
+    public void toModelType_invalidName_throwsIllegalValueException() {
+        CsvAdaptedPerson person = new CsvAdaptedPerson(
+                INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_INCOME, VALID_MEETING_DATE, VALID_TAGS);
+        String expectedMessage = Name.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullName_throwsIllegalValueException() {
+        CsvAdaptedPerson person = new CsvAdaptedPerson(
+                null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_INCOME, VALID_MEETING_DATE, VALID_TAGS);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidPhone_throwsIllegalValueException() {
+        CsvAdaptedPerson person = new CsvAdaptedPerson(
+                VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_INCOME, VALID_MEETING_DATE, VALID_TAGS);
+        String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullPhone_throwsIllegalValueException() {
+        CsvAdaptedPerson person = new CsvAdaptedPerson(
+                VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS, VALID_INCOME, VALID_MEETING_DATE, VALID_TAGS);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidEmail_throwsIllegalValueException() {
+        CsvAdaptedPerson person = new CsvAdaptedPerson(
+                VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_INCOME, VALID_MEETING_DATE, VALID_TAGS);
+        String expectedMessage = Email.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullEmail_throwsIllegalValueException() {
+        CsvAdaptedPerson person = new CsvAdaptedPerson(
+                VALID_NAME, VALID_PHONE, null, VALID_ADDRESS, VALID_INCOME, VALID_MEETING_DATE, VALID_TAGS);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidAddress_throwsIllegalValueException() {
+        CsvAdaptedPerson person = new CsvAdaptedPerson(
+                VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_INCOME, VALID_MEETING_DATE, VALID_TAGS);
+        String expectedMessage = Address.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullAddress_throwsIllegalValueException() {
+        CsvAdaptedPerson person = new CsvAdaptedPerson(
+                VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_INCOME, VALID_MEETING_DATE, VALID_TAGS);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidIncome_throwsIllegalValueException() {
+        CsvAdaptedPerson person = new CsvAdaptedPerson(
+                VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, INVALID_INCOME, VALID_MEETING_DATE, VALID_TAGS);
+        String expectedMessage = Income.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullIncome_throwsIllegalValueException() {
+        CsvAdaptedPerson person = new CsvAdaptedPerson(
+                VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, null, VALID_MEETING_DATE, VALID_TAGS);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Income.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidMeetingDate_throwsIllegalValueException() {
+        CsvAdaptedPerson person = new CsvAdaptedPerson(
+                VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_INCOME, INVALID_MEETING_DATE, VALID_TAGS);
+        String expectedMessage = MeetingDate.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+}

--- a/src/test/java/seedu/address/storage/StringToTagTest.java
+++ b/src/test/java/seedu/address/storage/StringToTagTest.java
@@ -1,0 +1,26 @@
+package seedu.address.storage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.tag.Tag;
+
+class StringToTagTest {
+
+    @Test
+    void validString_returnsTag() {
+        Tag tag = (Tag) new StringToTag().convertToRead("foobar");
+        Tag expectedTag = new Tag("foobar");
+        assertEquals(tag, expectedTag);
+    }
+
+    @Test
+    void invalidString_throwsRuntimeException() {
+        try {
+            new StringToTag().convertToRead("");
+        } catch (Exception e) {
+            assertEquals(RuntimeException.class, e.getClass());
+        }
+    }
+}


### PR DESCRIPTION
## Add `CSV` import
**usage:** `import <path to CSV file>`
**example:** `import ./data.csv` 

This command can be used to import persons from a `CSV` file

See diff for details on files added and modified.

### **Todo:**
- [x] implement `CSV` import
- [x] add new test cases
- [x] update user guide

### Plans for future iterations
Extend `CSV` import to support exporting of data in `CSV` format
