### PR TITLE
Add export command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -21,6 +21,7 @@ done faster and more securely than traditional GUI apps.
     * [Exiting the application: `exit`](#exiting-the-application--exit)
     * [Saving the data](#saving-the-data)
     * [Importing data: `import`](#importing-data--import)
+    * [Exporting data: `export`](#exporting-data--export)
 - [FAQ](#faq)
 - [Command Summary](#command-summary)
 
@@ -203,6 +204,23 @@ Examples:
 
 * `import ./data.json` imports data from the file `data.json` which is located in the same directory as the FinBook executable
 * `import ../data.csv` imports data from the file `data.csv` which is located one level outside the directory of the FinBook executable
+
+---
+
+### Exporting data : `export`
+
+Exports data to a `CSV` file
+
+Format: `export PATH`
+
+* Exports data to the file at the specified `PATH`
+* `PATH` can be a relative or full path
+* `PATH` must end in `.csv`
+
+Examples:
+
+* `export ./data.csv` exports data to the file `data.csv` which is located in the same directory as the FinBook executable
+* `export ../data.csv` exports data to the file `data.csv` which is located one level outside the directory of the FinBook executable
 
 --------------------------------------------------------------------------------------------------------------------
 

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -11,5 +11,6 @@ public class Messages {
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_INVALID_FILE_PATH = "Invalid file path! \n%1$s";
     public static final String MESSAGE_IMPORT_ERROR = "Error encountered while importing: \n%1$s";
+    public static final String MESSAGE_EXPORT_ERROR = "Error encountered while exporting: \n%1$s";
 
 }

--- a/src/main/java/seedu/address/logic/commands/ExportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExportCommand.java
@@ -1,0 +1,70 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_IMPORT_ERROR;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.opencsv.bean.StatefulBeanToCsv;
+import com.opencsv.bean.StatefulBeanToCsvBuilder;
+import com.opencsv.exceptions.CsvDataTypeMismatchException;
+import com.opencsv.exceptions.CsvRequiredFieldEmptyException;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.storage.CsvAdaptedPerson;
+
+/**
+ * Exports data to a CSV file located at the specified path.
+ */
+public class ExportCommand extends Command {
+
+    public static final String COMMAND_WORD = "export";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Exports data to a CSV file located at the specified path.\n"
+            + "Parameters: path to CSV file\n"
+            + "Examples: \n"
+            + COMMAND_WORD + " ./data.csv\n"
+            + "- exports data to the file \"data.csv\""
+            + " which is located in the same directory as the FinBook executable\n"
+            + COMMAND_WORD + " ../data.csv\n"
+            + "- exports data to the file \"data.csv\""
+            + " which is located one level outside the directory of the FinBook executable";
+
+    public static final String MESSAGE_IMPORT_DATA_SUCCESS = "Exported data: %1$s";
+
+    private final Path targetPath;
+
+    public ExportCommand(Path targetPath) {
+        this.targetPath = targetPath;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<CsvAdaptedPerson> beans = model.getAddressBook().getPersonList().stream()
+                .map(CsvAdaptedPerson::new).collect(Collectors.toList());
+        try {
+            Writer writer = new FileWriter(targetPath.toFile());
+            StatefulBeanToCsv beanToCsv = new StatefulBeanToCsvBuilder(writer).build();
+            beanToCsv.write(beans);
+            writer.close();
+        } catch (IOException | CsvRequiredFieldEmptyException | CsvDataTypeMismatchException e) {
+            throw new CommandException(String.format(MESSAGE_IMPORT_ERROR, e.getMessage()));
+        }
+        return new CommandResult(String.format(MESSAGE_IMPORT_DATA_SUCCESS, targetPath.getFileName()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ExportCommand // instanceof handles nulls
+                && targetPath.equals(((ExportCommand) other).targetPath)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/ExportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExportCommand.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.core.Messages.MESSAGE_IMPORT_ERROR;
+import static seedu.address.commons.core.Messages.MESSAGE_EXPORT_ERROR;
 
 import java.io.FileWriter;
 import java.io.Writer;
@@ -34,7 +34,7 @@ public class ExportCommand extends Command {
             + "- exports data to the file \"data.csv\""
             + " which is located one level outside the directory of the FinBook executable";
 
-    public static final String MESSAGE_IMPORT_DATA_SUCCESS = "Exported data: %1$s";
+    public static final String MESSAGE_EXPORT_DATA_SUCCESS = "Exported data: %1$s";
 
     private final Path targetPath;
 
@@ -53,9 +53,9 @@ public class ExportCommand extends Command {
             beanToCsv.write(beans);
             writer.close();
         } catch (Exception e) {
-            throw new CommandException(String.format(MESSAGE_IMPORT_ERROR, e.getMessage()));
+            throw new CommandException(String.format(MESSAGE_EXPORT_ERROR, e.getMessage()));
         }
-        return new CommandResult(String.format(MESSAGE_IMPORT_DATA_SUCCESS, targetPath.getFileName()));
+        return new CommandResult(String.format(MESSAGE_EXPORT_DATA_SUCCESS, targetPath.getFileName()));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/ExportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExportCommand.java
@@ -4,7 +4,6 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_IMPORT_ERROR;
 
 import java.io.FileWriter;
-import java.io.IOException;
 import java.io.Writer;
 import java.nio.file.Path;
 import java.util.List;
@@ -12,8 +11,6 @@ import java.util.stream.Collectors;
 
 import com.opencsv.bean.StatefulBeanToCsv;
 import com.opencsv.bean.StatefulBeanToCsvBuilder;
-import com.opencsv.exceptions.CsvDataTypeMismatchException;
-import com.opencsv.exceptions.CsvRequiredFieldEmptyException;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -55,7 +52,7 @@ public class ExportCommand extends Command {
             StatefulBeanToCsv beanToCsv = new StatefulBeanToCsvBuilder(writer).build();
             beanToCsv.write(beans);
             writer.close();
-        } catch (IOException | CsvRequiredFieldEmptyException | CsvDataTypeMismatchException e) {
+        } catch (Exception e) {
             throw new CommandException(String.format(MESSAGE_IMPORT_ERROR, e.getMessage()));
         }
         return new CommandResult(String.format(MESSAGE_IMPORT_DATA_SUCCESS, targetPath.getFileName()));

--- a/src/main/java/seedu/address/logic/commands/ImportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ImportCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_IMPORT_ERROR;
 
 import java.io.FileReader;
+import java.io.Reader;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -49,8 +50,10 @@ public class ImportCommand extends Command {
                 JsonAddressBookStorage tempStorage = new JsonAddressBookStorage(targetPath);
                 tempStorage.readAddressBook().ifPresent(x -> x.getPersonList().forEach(model::addPerson));
             } else {
-                List<CsvAdaptedPerson> beans = new CsvToBeanBuilder(new FileReader(targetPath.toFile()))
+                Reader reader = new FileReader(targetPath.toFile());
+                List<CsvAdaptedPerson> beans = new CsvToBeanBuilder(reader)
                         .withType(CsvAdaptedPerson.class).build().parse();
+                reader.close();
                 beans.forEach(x -> {
                     try {
                         model.addPerson(x.toModelType());

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -12,6 +12,7 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.ExportCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ImportCommand;
@@ -71,6 +72,9 @@ public class AddressBookParser {
 
         case ImportCommand.COMMAND_WORD:
             return new ImportCommandParser().parse(arguments);
+
+        case ExportCommand.COMMAND_WORD:
+            return new ExportCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/ExportCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ExportCommandParser.java
@@ -1,0 +1,31 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_FILE_PATH;
+
+import java.nio.file.Path;
+
+import seedu.address.logic.commands.ExportCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new ExportCommand object
+ */
+public class ExportCommandParser implements Parser<ExportCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the ExportCommand
+     * and returns an ExportCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ExportCommand parse(String args) throws ParseException {
+        try {
+            Path path = ParserUtil.parseExportPath(args);
+            return new ExportCommand(path);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_FILE_PATH, ExportCommand.MESSAGE_USAGE), pe);
+        }
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/ImportCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ImportCommandParser.java
@@ -20,7 +20,7 @@ public class ImportCommandParser implements Parser<ImportCommand> {
      */
     public ImportCommand parse(String args) throws ParseException {
         try {
-            Path path = ParserUtil.parsePath(args);
+            Path path = ParserUtil.parseImportPath(args);
             return new ImportCommand(path);
         } catch (ParseException pe) {
             throw new ParseException(

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -122,6 +122,7 @@ public class ParserUtil {
      * Parses a {@code String meetingDate} into an {@code MeetingDate}.
      * Leading and trailing whitespaces will be trimmed.
      * MeetingDate can be null.
+     *
      * @throws ParseException if the given {@code meetingDate} is invalid.
      */
     public static MeetingDate parseMeetingDate(String meetingDate) throws ParseException {
@@ -167,13 +168,28 @@ public class ParserUtil {
      * Parses {@code filePath} into an {@code Path} and returns it. Leading and trailing whitespaces will be
      * trimmed.
      *
-     * @throws ParseException if the specified path is invalid.
+     * @throws ParseException if the specified path is invalid (not JSON or CSV, or not readable)
      */
-    public static Path parsePath(String filePath) throws ParseException {
+    public static Path parseImportPath(String filePath) throws ParseException {
         String trimmedPath = filePath.trim();
         File file = new File(trimmedPath);
         if (!(file.getName().toLowerCase().endsWith(".json") || file.getName().toLowerCase().endsWith(".csv"))
                 || !Files.isReadable(file.toPath())) {
+            throw new ParseException(MESSAGE_INVALID_PATH);
+        }
+        return file.toPath();
+    }
+
+    /**
+     * Parses {@code filePath} into an {@code Path} and returns it. Leading and trailing whitespaces will be
+     * trimmed.
+     *
+     * @throws ParseException if the specified path is invalid (not CSV)
+     */
+    public static Path parseExportPath(String filePath) throws ParseException {
+        String trimmedPath = filePath.trim();
+        File file = new File(trimmedPath);
+        if (!file.getName().toLowerCase().endsWith(".csv")) {
             throw new ParseException(MESSAGE_INVALID_PATH);
         }
         return file.toPath();

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -48,7 +48,7 @@ public class Tag {
      * Format state as text for viewing.
      */
     public String toString() {
-        return '[' + tagName + ']';
+        return tagName;
     }
 
 }

--- a/src/main/java/seedu/address/storage/CsvAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/CsvAdaptedPerson.java
@@ -38,7 +38,7 @@ public class CsvAdaptedPerson {
     @CsvBindByName(column = "meeting date", required = true)
     private final String meetingDate;
     @CsvBindAndSplitByName(column = "tags", required = true,
-            elementType = Tag.class, splitOn = ",", converter = StringToTag.class)
+            elementType = Tag.class, splitOn = ",", converter = StringToTag.class, writeDelimiter = ",")
     private final List<Tag> tagged = new ArrayList<>();
 
     /**

--- a/src/main/java/seedu/address/storage/CsvAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/CsvAdaptedPerson.java
@@ -35,9 +35,9 @@ public class CsvAdaptedPerson {
     private final String address;
     @CsvBindByName(required = true)
     private final String income;
-    @CsvBindByName(column = "meeting date", required = true)
+    @CsvBindByName(column = "meeting date")
     private final String meetingDate;
-    @CsvBindAndSplitByName(column = "tags", required = true,
+    @CsvBindAndSplitByName(column = "tags",
             elementType = Tag.class, splitOn = ",", converter = StringToTag.class, writeDelimiter = ",")
     private final List<Tag> tagged = new ArrayList<>();
 
@@ -97,7 +97,9 @@ public class CsvAdaptedPerson {
     public Person toModelType() throws IllegalValueException {
         final List<Tag> personTags = new ArrayList<>();
         for (Tag tag : tagged) {
-            personTags.add(tag);
+            if (!tag.tagName.equals("null")) {
+                personTags.add(tag);
+            }
         }
 
         if (name == null) {

--- a/src/main/java/seedu/address/storage/StringToTag.java
+++ b/src/main/java/seedu/address/storage/StringToTag.java
@@ -2,7 +2,6 @@ package seedu.address.storage;
 
 import com.opencsv.bean.AbstractCsvConverter;
 
-import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -11,12 +10,8 @@ import seedu.address.model.tag.Tag;
 public class StringToTag extends AbstractCsvConverter {
     @Override
     public Object convertToRead(String value) {
-        if (!Tag.isValidTagName(value)) {
-            try {
-                throw new IllegalValueException(Tag.MESSAGE_CONSTRAINTS);
-            } catch (IllegalValueException e) {
-                throw new RuntimeException(e);
-            }
+        if (value.equals("")) {
+            return new Tag("null");
         }
         return new Tag(value);
     }

--- a/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
@@ -2,10 +2,9 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import static seedu.address.commons.core.Messages.MESSAGE_EXPORT_ERROR;
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TestUtil.getFilePathInSandboxFolder;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
@@ -59,10 +58,7 @@ public class ExportCommandTest {
     public void execute_invalidCsvPath_throwsCommandException() {
         ExportCommand exportCommand = new ExportCommand(invalidCsvPath);
 
-        assertCommandFailure(exportCommand, model,
-                String.format(MESSAGE_EXPORT_ERROR,
-                        "src\\test\\data\\sandbox\\nonexistent\\foobar.csv "
-                                + "(The system cannot find the path specified)"));
+        assertThrows(CommandException.class, () -> exportCommand.execute(model));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
@@ -1,0 +1,89 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static seedu.address.commons.core.Messages.MESSAGE_EXPORT_ERROR;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TestUtil.getFilePathInSandboxFolder;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code ImportCommand}.
+ */
+public class ExportCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Path dummyPath = Paths.get("foobar.csv");
+    private Path validCsvPath = getFilePathInSandboxFolder("foobar.csv");
+    private Path invalidCsvPath = getFilePathInSandboxFolder("nonexistent/foobar.csv");
+
+    @Test
+    public void execute_validCsvPath_success() {
+        ExportCommand exportCommand = new ExportCommand(validCsvPath);
+
+        String expectedMessage = String.format(ExportCommand.MESSAGE_EXPORT_DATA_SUCCESS, validCsvPath.getFileName());
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+
+        assertCommandSuccess(exportCommand, model, expectedMessage, expectedModel);
+
+        //Reimport exported CSV file and checking if model remains the same
+        Model importedModel = new ModelManager(new AddressBook(), new UserPrefs());
+        ImportCommand importCommand = new ImportCommand(validCsvPath);
+        try {
+            importCommand.execute(importedModel);
+        } catch (CommandException e) {
+            fail();
+        }
+        assertEquals(model, importedModel);
+        new File(validCsvPath.toUri()).delete();
+    }
+
+    @Test
+    public void execute_invalidCsvPath_throwsCommandException() {
+        ExportCommand exportCommand = new ExportCommand(invalidCsvPath);
+
+        assertCommandFailure(exportCommand, model,
+                String.format(MESSAGE_EXPORT_ERROR,
+                        "src\\test\\data\\sandbox\\nonexistent\\foobar.csv "
+                                + "(The system cannot find the path specified)"));
+    }
+
+    @Test
+    public void equals() {
+        ExportCommand exportFirstCommand = new ExportCommand(validCsvPath);
+        ExportCommand exportSecondCommand = new ExportCommand(dummyPath);
+
+        // same object -> returns true
+        assertTrue(exportFirstCommand.equals(exportFirstCommand));
+
+        // same values -> returns true
+        ExportCommand exportFirstCommandCopy = new ExportCommand(validCsvPath);
+        assertTrue(exportFirstCommand.equals(exportFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(exportFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(exportFirstCommand.equals(null));
+
+        // different path -> returns false
+        assertFalse(exportFirstCommand.equals(exportSecondCommand));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -22,6 +22,7 @@ import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.ExportCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ImportCommand;
@@ -53,7 +54,7 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_delete() throws Exception {
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
-            DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
+                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
         assertEquals(new DeleteCommand(INDEX_FIRST_PERSON), command);
     }
 
@@ -62,7 +63,7 @@ public class AddressBookParserTest {
         Person person = new PersonBuilder().build();
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(person).build();
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
-            + INDEX_FIRST_PERSON.getOneBased() + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
+                + INDEX_FIRST_PERSON.getOneBased() + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
         assertEquals(new EditCommand(INDEX_FIRST_PERSON, descriptor), command);
     }
 
@@ -76,7 +77,7 @@ public class AddressBookParserTest {
     public void parseCommand_find() throws Exception {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         FindCommand command = (FindCommand) parser.parseCommand(
-            FindCommand.COMMAND_WORD + " n/" + keywords.stream().collect(Collectors.joining(" n/")));
+                FindCommand.COMMAND_WORD + " n/" + keywords.stream().collect(Collectors.joining(" n/")));
         assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
     }
 
@@ -95,7 +96,7 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_unrecognisedInput_throwsParseException() {
         assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), ()
-            -> parser.parseCommand(""));
+                -> parser.parseCommand(""));
     }
 
     @Test
@@ -109,8 +110,16 @@ public class AddressBookParserTest {
         File dummyFile = new File(dummyPath.toUri());
         dummyFile.createNewFile();
         ImportCommand command = (ImportCommand) parser.parseCommand(
-            ImportCommand.COMMAND_WORD + " " + dummyPath.toString());
+                ImportCommand.COMMAND_WORD + " " + dummyPath.toString());
         assertEquals(new ImportCommand(dummyPath), command);
         dummyFile.delete();
+    }
+
+    @Test
+    public void parseCommand_export() throws Exception {
+        Path dummyPath = getFilePathInSandboxFolder("foobar.csv");
+        ExportCommand command = (ExportCommand) parser.parseCommand(
+                ExportCommand.COMMAND_WORD + " " + dummyPath.toString());
+        assertEquals(new ExportCommand(dummyPath), command);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/ExportCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ExportCommandParserTest.java
@@ -1,0 +1,29 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_FILE_PATH;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TestUtil.getFilePathInSandboxFolder;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.ExportCommand;
+
+public class ExportCommandParserTest {
+
+    private ExportCommandParser parser = new ExportCommandParser();
+
+    private Path validPath = getFilePathInSandboxFolder("foobar.csv");
+
+    @Test
+    public void parse_validArgs_returnsExportCommand() {
+        assertParseSuccess(parser, "src/test/data/sandbox/foobar.csv", new ExportCommand(validPath));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_FILE_PATH, ExportCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -200,13 +200,13 @@ public class ParserUtilTest {
 
     @Test
     public void parsePath_invalidInput_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parsePath("10 a"));
+        assertThrows(ParseException.class, () -> ParserUtil.parseImportPath("10 a"));
     }
 
     @Test
     public void parsePath_notReadable_throwsParseException() {
         assertThrows(ParseException.class, MESSAGE_INVALID_PATH, ()
-                -> ParserUtil.parsePath("foobar.json"));
+                -> ParserUtil.parseImportPath("foobar.json"));
     }
 
     @Test
@@ -215,10 +215,10 @@ public class ParserUtilTest {
         File dummyFile = new File(dummyPath.toUri());
         dummyFile.createNewFile();
         // No whitespaces
-        assertEquals(dummyPath, ParserUtil.parsePath(dummyPath.toString()));
+        assertEquals(dummyPath, ParserUtil.parseImportPath(dummyPath.toString()));
 
         // Leading and trailing whitespaces
-        assertEquals(dummyPath, ParserUtil.parsePath("  " + dummyPath.toString() + "  "));
+        assertEquals(dummyPath, ParserUtil.parseImportPath("  " + dummyPath.toString() + "  "));
         dummyFile.delete();
     }
 }

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -199,18 +199,18 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void parsePath_invalidInput_throwsParseException() {
+    public void parseImportPath_invalidInput_throwsParseException() {
         assertThrows(ParseException.class, () -> ParserUtil.parseImportPath("10 a"));
     }
 
     @Test
-    public void parsePath_notReadable_throwsParseException() {
+    public void parseImportPath_notReadable_throwsParseException() {
         assertThrows(ParseException.class, MESSAGE_INVALID_PATH, ()
                 -> ParserUtil.parseImportPath("foobar.json"));
     }
 
     @Test
-    public void parsePath_validInput_success() throws Exception {
+    public void parseImportPath_validInput_success() throws Exception {
         Path dummyPath = getFilePathInSandboxFolder("foobar.json");
         File dummyFile = new File(dummyPath.toUri());
         dummyFile.createNewFile();
@@ -220,5 +220,20 @@ public class ParserUtilTest {
         // Leading and trailing whitespaces
         assertEquals(dummyPath, ParserUtil.parseImportPath("  " + dummyPath.toString() + "  "));
         dummyFile.delete();
+    }
+
+    @Test
+    public void parseExportPath_invalidInput_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseExportPath("10 a"));
+    }
+
+    @Test
+    public void parseExportPath_validInput_success() throws Exception {
+        Path dummyPath = getFilePathInSandboxFolder("foobar.csv");
+        // No whitespaces
+        assertEquals(dummyPath, ParserUtil.parseExportPath(dummyPath.toString()));
+
+        // Leading and trailing whitespaces
+        assertEquals(dummyPath, ParserUtil.parseExportPath("  " + dummyPath.toString() + "  "));
     }
 }


### PR DESCRIPTION
## Add `export` command
**usage:** `export <path to file>`
**example:** export ./data/addressbook.csv` 

This command can be used to export persons to a file in `csv` format.

See diff for details on files added and modified.

### **Todo:**
- [x] implement `export` command
- [x] add new test cases
- [x] update user guide